### PR TITLE
ポストにURLを含めないようにした

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -164,12 +164,10 @@ sendToot toot = do
 --     | otherwise = return $ Right ()
 
 tootToTweet :: T.Text -> Toot -> Maybe TW.Post
-tootToTweet catchingTag (Toot { tootContent = content, tootUrl = url }) =
+tootToTweet catchingTag (Toot { tootContent = content, tootUrl = _url }) =
     let content' = either (const Nothing) (Just . removeHashTag catchingTag) $ htmlToPlain $ content
     in
-        case url of
-            Nothing   -> mkPost <$> content'
-            Just url' -> mkPost . addUrl url' . truncate (postMaxChars - postUrlChars - 2 - P.length ("[ｆｒｏｍ]:" :: String)) <$> content'
+        mkPost <$> content'
 
 removeHashTag :: T.Text -> T.Text -> T.Text
 removeHashTag tagName content = T.unlines . filter ((/= ("#" <> T.toLower tagName)) . T.toLower) . T.lines $ content

--- a/relay-mstdn-toots.cabal
+++ b/relay-mstdn-toots.cabal
@@ -20,7 +20,7 @@ name:               relay-mstdn-toots
 -- PVP summary:     +-+------- breaking API changes
 --                  | | +----- non-breaking API additions
 --                  | | | +--- code changes with no API change
-version:            0.2.0.0
+version:            0.2.1.0
 
 -- A short (one-line) description of the package.
 -- synopsis:


### PR DESCRIPTION
X 側のポストに元トゥートの URL が含まれないようにした（リンクカードが生成されるのが煩わしいため）